### PR TITLE
Rocks block enemies

### DIFF
--- a/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
+++ b/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -22,6 +23,8 @@ public class BoardManager : MonoBehaviour
     public GameObject lastSelectedGem;
     public GameObject lastSelectedGameObject;
     private GameObject currentSelectedGameObject_Recent;
+
+    private List<Checkpoint> checkpoints;
 
     public static char[,] bigBoard = new char[19, 20]
     {
@@ -74,6 +77,7 @@ public class BoardManager : MonoBehaviour
     {
         int height = board.GetLength(0);
         int width = board.GetLength(1);
+        checkpoints = new List<Checkpoint>();
         for (int i = 0; i < width; i++)
         {
             for (int j = 0; j < height; j++)
@@ -88,14 +92,16 @@ public class BoardManager : MonoBehaviour
                         Instantiate(pathTiles[0], new Vector3(i, height - j - 1, 0), Quaternion.identity);
                         break;
                     default:
+                        int index = (int)char.GetNumericValue(board[j, i]);
+                        checkpoints.Add(new Checkpoint(index, i, height - j - 1));
                         Instantiate(pathTiles[1], new Vector3(i, height - j - 1, 0), Quaternion.identity);
                         break;
                 }
-
             }
         }
+        checkpoints = checkpoints.OrderBy(c => c.ZeroIndexCheckpointNumber).ToList();
     }
-    
+
     // Update is called once per frame
     void Update()
     {

--- a/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
+++ b/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
@@ -63,7 +63,24 @@ public class BoardManager : MonoBehaviour
         {'G','G','G','G','G','G','G','G','G','G','G'}
     };
 
-    public char[,] board = bigBoard;
+    public char[,] board = FlipAndInvertBoard(bigBoard);
+
+    // Flips a visually correct board into an array that has correct X,Y coordinates
+    // ie. board[X,Y] gives you the object at X,Y instead of the object at Y,-X
+    private static char[,] FlipAndInvertBoard(char[,] visuallyAppealingBoard)
+    {
+        int dimension0Count = visuallyAppealingBoard.GetLength(0);
+        int dimension1Count = visuallyAppealingBoard.GetLength(1);
+        char[,] properlyCoordinatedBoard = new char[dimension1Count, dimension0Count];
+        for (int i = 0; i < dimension1Count; i++)
+        {
+            for (int j = 0; j < dimension0Count; j++)
+            {
+                properlyCoordinatedBoard[i, j] = visuallyAppealingBoard[dimension0Count - j - 1, i];
+            }
+        }
+        return properlyCoordinatedBoard;
+    }
 
     // Use this for initialization
     void Start()
@@ -75,26 +92,28 @@ public class BoardManager : MonoBehaviour
 
     private void InitializeBoard()
     {
-        int height = board.GetLength(0);
-        int width = board.GetLength(1);
+        int width = board.GetLength(0);
+        int height = board.GetLength(1);
         checkpoints = new List<Checkpoint>();
-        for (int i = 0; i < width; i++)
+        for (int x = 0; x < width; x++)
         {
-            for (int j = 0; j < height; j++)
+            for (int y = 0; y < height; y++)
             {
-                switch (board[j, i])
+                switch (board[x, y])
                 // I think I'll need to set the parent of these things, to make them appear on the canvas layers correctly
                 {
                     case 'G':
-                        Instantiate(groundTiles[UnityEngine.Random.Range(0, groundTiles.Length)], new Vector3(i, height - j - 1, 0), Quaternion.identity);
+                        Instantiate(groundTiles[UnityEngine.Random.Range(0, groundTiles.Length)], new Vector3(x, y, 0), Quaternion.identity);
                         break;
                     case 'P':
-                        Instantiate(pathTiles[0], new Vector3(i, height - j - 1, 0), Quaternion.identity);
+                        Instantiate(pathTiles[0], new Vector3(x, y, 0), Quaternion.identity);
+                        break;
+                    case 'X':
                         break;
                     default:
-                        int index = (int)char.GetNumericValue(board[j, i]);
-                        checkpoints.Add(new Checkpoint(index, i, height - j - 1));
-                        Instantiate(pathTiles[1], new Vector3(i, height - j - 1, 0), Quaternion.identity);
+                        int index = (int)char.GetNumericValue(board[x, y]);
+                        checkpoints.Add(new Checkpoint(index, x, y));
+                        Instantiate(pathTiles[1], new Vector3(x, y, 0), Quaternion.identity);
                         break;
                 }
             }

--- a/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
+++ b/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
@@ -24,7 +24,7 @@ public class BoardManager : MonoBehaviour
     public GameObject lastSelectedGameObject;
     private GameObject currentSelectedGameObject_Recent;
 
-    private List<Checkpoint> checkpoints;
+    public List<Checkpoint> checkpoints;
 
     public static char[,] bigBoard = new char[19, 20]
     {
@@ -41,10 +41,10 @@ public class BoardManager : MonoBehaviour
         {'G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G'},
         {'G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G'},
         {'G','G','G','G','G','G','G','G','2','P','P','P','P','P','P','P','P','P','P','3'},
-        {'G','G','G','G','G','G','G','G','P','G','G','G','G','G','G','G','G','G','G','G'},
-        {'G','G','G','G','G','G','G','G','P','G','G','G','G','G','G','G','G','G','G','G'},
-        {'0','P','P','P','P','P','P','P','1','G','G','G','G','G','G','G','G','G','G','G'},
-        {'G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G'},
+        {'G','G','G','G','G','G','G','X','X','G','G','G','G','G','G','G','G','G','G','G'},
+        {'G','G','G','G','G','G','G','X','P','G','G','G','G','G','G','G','G','G','G','G'},
+        {'0','P','P','P','P','P','P','X','1','G','G','G','G','G','G','G','G','G','G','G'},
+        {'G','G','G','G','G','G','G','X','G','G','G','G','G','G','G','G','G','G','G','G'},
         {'G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G'},
         {'G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G','G'}
     };

--- a/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
+++ b/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
@@ -181,10 +181,10 @@ public class BoardManager : MonoBehaviour
             List<Vector3> spacesAvailable = FindNextSpace(exploredSpaces, currentPath.Item1);
             foreach(var currentSpace in spacesAvailable)
             {
-                var path = currentPath.Item2;
+                var path = new List<Vector3>(currentPath.Item2);
                 path.Add(currentPath.Item1);
                 exploredSpaces.Add(currentSpace);
-                exploredPaths.Enqueue(Tuple.Create(currentSpace, new List<Vector3>(path)));
+                exploredPaths.Enqueue(Tuple.Create(currentSpace, path));
             }
             exploredPaths.Dequeue();
         }
@@ -194,16 +194,16 @@ public class BoardManager : MonoBehaviour
     private List<Vector3> FindNextSpace(List<Vector3> exploredSpaces, Vector3 currentSpace)
     {
         List<Vector3> emptySpaces = new List<Vector3>();
-        int height = board.GetLength(0);
-        int width = board.GetLength(1);
+        int width = board.GetLength(0);
+        int height = board.GetLength(1);
         int x = (int)currentSpace.x;
         int y = (int)currentSpace.y;
 
         // try move up -> left -> right -> down
-        if ((y + 1) < height && board[y + 1, x] != 'X') emptySpaces.Add(new Vector3(x, y + 1, 0));
-        if ((x - 1) >= 0     && board[y, x - 1] != 'X') emptySpaces.Add(new Vector3(x - 1, y, 0));
-        if ((x + 1) < width  && board[y, x + 1] != 'X') emptySpaces.Add(new Vector3(x + 1, y, 0));
-        if ((y - 1) >= 0     && board[y - 1, x] != 'X') emptySpaces.Add(new Vector3(x, y - 1, 0));
+        if ((y + 1) < height && board[x, y + 1] != 'X') emptySpaces.Add(new Vector3(x, y + 1, 0));
+        if ((x - 1) >= 0     && board[x - 1, y] != 'X') emptySpaces.Add(new Vector3(x - 1, y, 0));
+        if ((x + 1) < width  && board[x + 1, y] != 'X') emptySpaces.Add(new Vector3(x + 1, y, 0));
+        if ((y - 1) >= 0     && board[x, y - 1] != 'X') emptySpaces.Add(new Vector3(x, y - 1, 0));
         return emptySpaces.Except(exploredSpaces).ToList();
     }
 

--- a/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
+++ b/Gem Tower Defense/Assets/Sciprts/BoardManager.cs
@@ -146,10 +146,9 @@ public class BoardManager : MonoBehaviour
         if (freshlyPlacedTiles.Count >= 5 ) throw new Exception("There were already 5 freshly placed gems");
         if (gameState != GameStates.PLACING_GEMS) throw new Exception("Right now it is not time for gems to be placed");
 
-        Debug.Log("place random tile got called with" + x + "  - " + y);
-        var freshlyPlacedGem = Instantiate(chippedGems[UnityEngine.Random.Range(0, chippedGems.Length)], new Vector3(x, y, 0), Quaternion.identity);
-        freshlyPlacedTiles.Push(freshlyPlacedGem);
-        lastSelectedGem = freshlyPlacedGem;
+        Debug.Log("place random tile got called with: " + x + "  - " + y);
+        
+        PlaceAndSelectRandomizedGem(x,y);
 
         if (freshlyPlacedTiles.Count >= 5)
         {
@@ -205,6 +204,13 @@ public class BoardManager : MonoBehaviour
         if ((x + 1) < width  && board[x + 1, y] != 'X') emptySpaces.Add(new Vector3(x + 1, y, 0));
         if ((y - 1) >= 0     && board[x, y - 1] != 'X') emptySpaces.Add(new Vector3(x, y - 1, 0));
         return emptySpaces.Except(exploredSpaces).ToList();
+    }
+
+    private void PlaceAndSelectRandomizedGem(float x, float y)
+    {
+        var freshlyPlacedGem = Instantiate(chippedGems[UnityEngine.Random.Range(0, chippedGems.Length)], new Vector3(x, y, 0), Quaternion.identity);
+        freshlyPlacedTiles.Push(freshlyPlacedGem);
+        lastSelectedGem = freshlyPlacedGem;
     }
 
     public void PlaceRockTile(float x, float y)

--- a/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs
+++ b/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs
@@ -1,13 +1,15 @@
-﻿public class Checkpoint
+﻿using UnityEngine;
+using System.Collections.Generic;
+
+public class Checkpoint
 {
     public int ZeroIndexCheckpointNumber { get; set; }
-    public float X { get; set; }
-    public float Y { get; set; }
+    public Vector3 Position { get; set; }
+    public List<Vector3> PathToCheckpoint { get; set; } 
 
     public Checkpoint(int index, float x, float y)
     {
         ZeroIndexCheckpointNumber = index;
-        X = x;
-        Y = y;
+        Position = new Vector3(x, y, 0);
     }
 }

--- a/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs
+++ b/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs
@@ -1,0 +1,13 @@
+﻿public class Checkpoint
+{
+    public int ZeroIndexCheckpointNumber { get; set; }
+    public float X { get; set; }
+    public float Y { get; set; }
+
+    public Checkpoint(int index, float x, float y)
+    {
+        ZeroIndexCheckpointNumber = index;
+        X = x;
+        Y = y;
+    }
+}

--- a/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs.meta
+++ b/Gem Tower Defense/Assets/Sciprts/Checkpoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 460397b70e0838f4eb09dcfbb766ab96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Gem Tower Defense/Assets/Sciprts/Enemy.cs
+++ b/Gem Tower Defense/Assets/Sciprts/Enemy.cs
@@ -10,25 +10,32 @@ public class Enemy : GameboardEntity, IDescribable
     public float speed;
     private Vector3 currentTarget;
     private int targetNumber = 0;
-    private Vector3[] targets = new Vector3[3];
+    private List<Vector3> targets = new List<Vector3>();
+    BoardManager boardManager;
 
     // Start is called before the first frame update
     public override void Start()
     {
         base.Start();
+        boardManager = (BoardManager)GameObject.Find("GameBoard").GetComponent(typeof(BoardManager));
+        List<Checkpoint> checkpoints = boardManager.checkpoints;
 
         hp = 10;
         speed = 3f;
 
-        LoadTargets();
+        LoadTargets(checkpoints);
         GetInitialTarget();
     }
 
-    private void LoadTargets()
+    private void LoadTargets(List<Checkpoint> checkpoints)
     {
-        targets[0] = new Vector3(8, 3, 0);
-        targets[1] = new Vector3(8, 6, 0);
-        targets[2] = new Vector3(19, 6, 0);
+        foreach (Checkpoint c in checkpoints)
+        {
+            foreach (Vector3 target in c.PathToCheckpoint)
+            {
+                targets.Add(target);
+            }
+        }
     }
 
     private void GetInitialTarget()
@@ -48,7 +55,7 @@ public class Enemy : GameboardEntity, IDescribable
         // check if target reached
         if (transform.position == currentTarget)
         {
-            if (targetNumber == targets.Length - 1)
+            if (targetNumber == targets.Count - 1)
             {
                 DestroyEnemy();
                 return;


### PR DESCRIPTION
Rocks that are (for now) pre-loaded on the map using X's to mark blocked tiles block an enemy's path. Enemies now find the shortest route to the next checkpoint and use it to travel along the board.

Only enemies that are spawned onto the map will move correctly, preloaded enemies don't behave properly